### PR TITLE
update-pod-version

### DIFF
--- a/react-native-fbsdk.podspec
+++ b/react-native-fbsdk.podspec
@@ -14,17 +14,17 @@ Pod::Spec.new do |s|
   s.dependency      'React'
 
   s.subspec 'Core' do |ss|
-    ss.dependency     'FBSDKCoreKit', '~> 5.0'
+    ss.dependency     'FBSDKCoreKit', '~> 5.5'
     ss.source_files = 'ios/RCTFBSDK/core/*.{h,m}'
   end
 
   s.subspec 'Login' do |ss|
-    ss.dependency     'FBSDKLoginKit', '~> 5.0'
+    ss.dependency     'FBSDKLoginKit', '~> 5.5'
     ss.source_files = 'ios/RCTFBSDK/login/*.{h,m}'
   end
 
   s.subspec 'Share' do |ss|
-    ss.dependency     'FBSDKShareKit', '~> 5.0'
+    ss.dependency     'FBSDKShareKit', '~> 5.5'
     ss.source_files = 'ios/RCTFBSDK/share/*.{h,m}'
   end
 end


### PR DESCRIPTION
Hi,

I had crash each time I push the button facebook login on the ios 13.

https://github.com/facebook/facebook-objc-sdk/blob/master/CHANGELOG.md#fixed-2

By updating the pods it's fixed my issue 


